### PR TITLE
Changed RabbitMQ log level for certain messages

### DIFF
--- a/software/incubator/communication/server/rabbitmq.py
+++ b/software/incubator/communication/server/rabbitmq.py
@@ -45,11 +45,11 @@ class Rabbitmq:
         if self.channel is not None:
             if not self.channel.is_closed and not self.connection.is_closed:
                 self.close()
-        self._l.info("Connection closed.")
+        self._l.debug("Connection closed.")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
-        self._l.info("Connection closed.")
+        self._l.debug("Connection closed.")
 
     def __enter__(self):
         self.connect_to_server()
@@ -57,7 +57,7 @@ class Rabbitmq:
 
     def connect_to_server(self):
         self.connection = pika.BlockingConnection(self.parameters)
-        self._l.info("Connected.")
+        self._l.debug("Connected.")
         self.channel = self.connection.channel()
         self.channel.exchange_declare(exchange=self.exchange_name, exchange_type=self.exchange_type)
 


### PR DESCRIPTION
Due to the `HeaterMock` implementation, we get the log message below whenever a heater actuator message is sent:
````
...
14/03 08:22:28  3.00                0.01     True       True    21.00  21.00                Heating
2024-03-14 08:22:31.859 INFO RabbitMQClass : Connected.
2024-03-14 08:22:31.865 INFO RabbitMQClass : Connection closed.
2024-03-14 08:22:31.865 INFO RabbitMQClass : Connection closed.
14/03 08:22:31  3.00                0.02     True       True    21.00  21.00                Heating
...
````
I understand that this is intended behaviour but it is confusing to new users of the incubator (e.g. in [this PR comment](https://github.com/INTO-CPS-Association/DTaaS-examples/pull/37#issuecomment-1992006074) ).
Furthermore, the log message does not bring any useful information to normal users, which is why I propose to lower the log level.